### PR TITLE
Put quotes around the query

### DIFF
--- a/query_parser.go
+++ b/query_parser.go
@@ -52,7 +52,7 @@ func (qp *StandardQueryParser) BuildParser() string {
 	}
 
 	if qp.q != "" {
-		kv = append(kv, fmt.Sprintf("v=%s", qp.q))
+		kv = append(kv, fmt.Sprintf("v=%q", qp.q))
 	}
 
 	return fmt.Sprintf("{!%s}", strings.Join(kv, " "))


### PR DESCRIPTION
Was having issues with query that contained a space. Was unable to use the `\ ` and other techniques. I may not be doing this corrcetly, please let me know.