### PR TITLE
Add EscapeQueryChars util function

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,26 @@
+package solr
+
+import (
+	"strings"
+	"unicode"
+)
+
+// EscapeQueryChars escapes special characters in the given Solr query string that would normally be treated as part of
+// Solr's query syntax. For a full list of special characters, see the Solr documentation here:
+// https://solr.apache.org/guide/solr/9_7/query-guide/standard-query-parser.html#escaping-special-characters
+//
+// Returns the query string with special characters escaped
+func EscapeQueryChars(s string) string {
+	var sb strings.Builder
+	for _, c := range s {
+		switch c {
+		case '\\', '+', '-', '!', '(', ')', ':', '^', '[', ']', '"', '{', '}', '~', '*', '?', '|', '&', ';', '/':
+			sb.WriteRune('\\')
+		}
+		if unicode.IsSpace(c) {
+			sb.WriteRune('\\')
+		}
+		sb.WriteRune(c)
+	}
+	return sb.String()
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,22 @@
+package solr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeQueryChars(t *testing.T) {
+	a := assert.New(t)
+	queryFromDocs := "(1+1):2"
+	expected := `\(1\+1\)\:2`
+	a.Equal(expected, EscapeQueryChars(queryFromDocs))
+
+	queryAllSpecialChars := `\+-!():^[]"{}~*?|&;/`
+	expected2 := `\\\+\-\!\(\)\:\^\[\]\"\{\}\~\*\?\|\&\;\/`
+	a.Equal(expected2, EscapeQueryChars(queryAllSpecialChars))
+
+	queryWhitespace := `	solr rocks`
+	expected3 := `\	solr\ rocks`
+	a.Equal(expected3, EscapeQueryChars(queryWhitespace))
+}


### PR DESCRIPTION
Add EscapeQueryChars util function based on [solr docs](https://solr.apache.org/guide/solr/9_7/query-guide/standard-query-parser.html#escaping-special-characters). (I put it in a utils file but I can move it elsewhere if preferred)

closes #29 